### PR TITLE
feat(N-006): 学年計算ロジックの単体テスト追加

### DIFF
--- a/frontend/src/utils/gradeCalculator.test.js
+++ b/frontend/src/utils/gradeCalculator.test.js
@@ -1,0 +1,263 @@
+import { calculateStudentInfo } from './gradeCalculator';
+
+/**
+ * テストの再現性確保のため基準日を固定（NFR-001）
+ * 2026年4月15日（新年度開始後）を標準基準日とする
+ */
+const REF_DATE = new Date('2026-04-15');
+
+describe('calculateStudentInfo', () => {
+
+  // ----------------------------------------------------------------
+  // AC-071: 年齢計算の精度（誕生日当日と前日の挙動）
+  // ----------------------------------------------------------------
+  describe('年齢計算（AC-071）', () => {
+    it('誕生日当日に年齢が加算される', () => {
+      // 2006-04-15生まれ、基準日2026-04-15 → 満20歳当日
+      const result = calculateStudentInfo('2006-04-15', REF_DATE);
+      expect(result.age).toBe(20);
+    });
+
+    it('誕生日前日はまだ年齢が加算されない', () => {
+      // 2006-04-16生まれ、基準日2026-04-15 → 翌日に20歳になる（19歳）
+      const result = calculateStudentInfo('2006-04-16', REF_DATE);
+      expect(result.age).toBe(19);
+    });
+
+    it('誕生日翌日以降は年齢が加算済み', () => {
+      // 2006-04-14生まれ、基準日2026-04-15 → 昨日20歳になった
+      const result = calculateStudentInfo('2006-04-14', REF_DATE);
+      expect(result.age).toBe(20);
+    });
+
+    it('誕生月が基準月より前の場合は計算年差がそのまま年齢', () => {
+      // 2000-03-31生まれ、基準日2026-04-15 → 26歳（3月 < 4月）
+      const result = calculateStudentInfo('2000-03-31', REF_DATE);
+      expect(result.age).toBe(26);
+    });
+
+    it('誕生月が基準月より後の場合は計算年差から1引く', () => {
+      // 2010-12-01生まれ、基準日2026-04-15 → 15歳（12月 > 4月）
+      const result = calculateStudentInfo('2010-12-01', REF_DATE);
+      expect(result.age).toBe(15);
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // AC-072: 学年判定の正確性（4月1日生まれと4月2日生まれの差異）
+  // ----------------------------------------------------------------
+  describe('4月1日と4月2日生まれの学年差異（AC-072）', () => {
+    it('4月1日生まれは前の学年にカウントされる（小学校2年生）', () => {
+      // 2019-04-01生まれ → startYear = 2025, diff = 2026-2025+1 = 2
+      const result = calculateStudentInfo('2019-04-01', REF_DATE);
+      expect(result.gradeLabel).toBe('小学校 2年生');
+      expect(result.stage).toBe('es');
+    });
+
+    it('4月2日生まれは後の学年にカウントされる（小学校1年生）', () => {
+      // 2019-04-02生まれ → startYear = 2026, diff = 2026-2026+1 = 1
+      const result = calculateStudentInfo('2019-04-02', REF_DATE);
+      expect(result.gradeLabel).toBe('小学校 1年生');
+      expect(result.stage).toBe('es');
+    });
+
+    it('3月31日生まれと4月1日生まれは同じ学年になる', () => {
+      // どちらも startYear = 2025 → diff = 2（小学校2年生）
+      const result1 = calculateStudentInfo('2019-03-31', REF_DATE);
+      const result2 = calculateStudentInfo('2019-04-01', REF_DATE);
+      expect(result1.gradeLabel).toBe(result2.gradeLabel);
+    });
+
+    it('4月1日生まれと4月2日生まれは学年が異なる', () => {
+      const result1 = calculateStudentInfo('2019-04-01', REF_DATE);
+      const result2 = calculateStudentInfo('2019-04-02', REF_DATE);
+      expect(result1.gradeLabel).not.toBe(result2.gradeLabel);
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // AC-070: 境界値テスト（小学校入学前後、学年境界）
+  // ----------------------------------------------------------------
+  describe('学校段階・学年の境界値（AC-070）', () => {
+
+    describe('未就学 → 小学校1年生の境界', () => {
+      it('4月1日生まれは入学年に小学校1年生になる', () => {
+        // 2020-04-01生まれ → startYear = 2026, diff = 2026-2026+1 = 1
+        const result = calculateStudentInfo('2020-04-01', REF_DATE);
+        expect(result.gradeLabel).toBe('小学校 1年生');
+        expect(result.stage).toBe('es');
+      });
+
+      it('4月2日生まれは同年度は未就学のまま', () => {
+        // 2020-04-02生まれ → startYear = 2027, diff = 2026-2027+1 = 0
+        const result = calculateStudentInfo('2020-04-02', REF_DATE);
+        expect(result.gradeLabel).toBe('未就学');
+        expect(result.stage).toBe('es');
+      });
+    });
+
+    describe('小学校6年生 → 中学校1年生の境界', () => {
+      it('diff=6（4月2日生まれ）は小学校6年生', () => {
+        // 2014-04-02生まれ → startYear = 2021, diff = 2026-2021+1 = 6
+        const result = calculateStudentInfo('2014-04-02', REF_DATE);
+        expect(result.gradeLabel).toBe('小学校 6年生');
+        expect(result.stage).toBe('es');
+      });
+
+      it('diff=7（4月1日生まれ）は中学校1年生', () => {
+        // 2014-04-01生まれ → startYear = 2020, diff = 2026-2020+1 = 7
+        const result = calculateStudentInfo('2014-04-01', REF_DATE);
+        expect(result.gradeLabel).toBe('中学校 1年生');
+        expect(result.stage).toBe('jhs');
+      });
+    });
+
+    describe('中学校3年生 → 高校1年生の境界', () => {
+      it('diff=9（4月2日生まれ）は中学校3年生', () => {
+        // 2011-04-02生まれ → startYear = 2018, diff = 2026-2018+1 = 9
+        const result = calculateStudentInfo('2011-04-02', REF_DATE);
+        expect(result.gradeLabel).toBe('中学校 3年生');
+        expect(result.stage).toBe('jhs');
+      });
+
+      it('diff=10（4月1日生まれ）は高校1年生', () => {
+        // 2011-04-01生まれ → startYear = 2017, diff = 2026-2017+1 = 10
+        const result = calculateStudentInfo('2011-04-01', REF_DATE);
+        expect(result.gradeLabel).toBe('高校 1年生');
+        expect(result.stage).toBe('hs');
+      });
+    });
+
+    describe('高校3年生 → 卒業生の境界', () => {
+      it('diff=12（4月2日生まれ）は高校3年生', () => {
+        // 2008-04-02生まれ → startYear = 2015, diff = 2026-2015+1 = 12
+        const result = calculateStudentInfo('2008-04-02', REF_DATE);
+        expect(result.gradeLabel).toBe('高校 3年生');
+        expect(result.stage).toBe('hs');
+      });
+
+      it('diff=13（4月1日生まれ）は卒業生', () => {
+        // 2008-04-01生まれ → startYear = 2014, diff = 2026-2014+1 = 13
+        const result = calculateStudentInfo('2008-04-01', REF_DATE);
+        expect(result.gradeLabel).toBe('卒業生');
+        expect(result.stage).toBe('hs');
+      });
+    });
+
+    describe('各学校段階の中間学年', () => {
+      it('小学校3年生（diff=3）', () => {
+        // 2018-04-02生まれ → startYear = 2025, diff = 2026-2025+1 = 2... 待って
+        // 2018-04-02生まれ → startYear = 2025, diff = 2026-2025+1 = 2 → 小学校2年生
+        // ではなく 2017-04-02生まれ → startYear = 2024, diff = 2026-2024+1 = 3
+        const result = calculateStudentInfo('2017-04-02', REF_DATE);
+        expect(result.gradeLabel).toBe('小学校 3年生');
+        expect(result.stage).toBe('es');
+      });
+
+      it('中学校2年生（diff=8）', () => {
+        // 2012-04-02生まれ → startYear = 2019, diff = 2026-2019+1 = 8
+        const result = calculateStudentInfo('2012-04-02', REF_DATE);
+        expect(result.gradeLabel).toBe('中学校 2年生');
+        expect(result.stage).toBe('jhs');
+      });
+
+      it('高校2年生（diff=11）', () => {
+        // 2009-04-02生まれ → startYear = 2016, diff = 2026-2016+1 = 11
+        const result = calculateStudentInfo('2009-04-02', REF_DATE);
+        expect(result.gradeLabel).toBe('高校 2年生');
+        expect(result.stage).toBe('hs');
+      });
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // AC-073: isAdult フラグの正確性（満20歳境界）
+  // ----------------------------------------------------------------
+  describe('isAdult フラグ（AC-073）', () => {
+    it('満20歳の誕生日当日に isAdult が true になる', () => {
+      // 2006-04-15生まれ、基準日2026-04-15 → 満20歳当日
+      const result = calculateStudentInfo('2006-04-15', REF_DATE);
+      expect(result.isAdult).toBe(true);
+      expect(result.age).toBe(20);
+    });
+
+    it('満20歳の誕生日前日は isAdult が false のまま', () => {
+      // 2006-04-16生まれ、基準日2026-04-15 → まだ19歳
+      const result = calculateStudentInfo('2006-04-16', REF_DATE);
+      expect(result.isAdult).toBe(false);
+      expect(result.age).toBe(19);
+    });
+
+    it('満20歳の誕生日翌日以降も isAdult が true', () => {
+      // 2006-04-14生まれ、基準日2026-04-15 → 昨日20歳になった
+      const result = calculateStudentInfo('2006-04-14', REF_DATE);
+      expect(result.isAdult).toBe(true);
+    });
+
+    it('19歳（20歳の1年前）は isAdult が false', () => {
+      // 2007-04-15生まれ、基準日2026-04-15 → 19歳
+      const result = calculateStudentInfo('2007-04-15', REF_DATE);
+      expect(result.isAdult).toBe(false);
+      expect(result.age).toBe(19);
+    });
+
+    it('21歳以上も isAdult が true', () => {
+      // 2005-04-15生まれ、基準日2026-04-15 → 21歳
+      const result = calculateStudentInfo('2005-04-15', REF_DATE);
+      expect(result.isAdult).toBe(true);
+      expect(result.age).toBe(21);
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // 学校年度境界（1〜3月は前年度扱い）
+  // ----------------------------------------------------------------
+  describe('学校年度の境界（1〜3月は前年度扱い）', () => {
+    it('1月基準日では前年度として計算される', () => {
+      // referenceDate = 2026-01-15 → currentSchoolYear = 2025
+      // 2019-04-01生まれ → startYear = 2025, diff = 2025-2025+1 = 1 → 小学校1年生
+      const refJan = new Date('2026-01-15');
+      const result = calculateStudentInfo('2019-04-01', refJan);
+      expect(result.gradeLabel).toBe('小学校 1年生');
+    });
+
+    it('3月31日基準日では前年度として計算される', () => {
+      // referenceDate = 2026-03-31 → currentSchoolYear = 2025
+      // 2020-04-01生まれ → startYear = 2026, diff = 2025-2026+1 = 0 → 未就学
+      const refMar = new Date('2026-03-31');
+      const result = calculateStudentInfo('2020-04-01', refMar);
+      expect(result.gradeLabel).toBe('未就学');
+    });
+
+    it('4月1日基準日では新年度として計算される', () => {
+      // referenceDate = 2026-04-01 → currentSchoolYear = 2026
+      // 2020-04-01生まれ → startYear = 2026, diff = 2026-2026+1 = 1 → 小学校1年生
+      const refApr1 = new Date('2026-04-01');
+      const result = calculateStudentInfo('2020-04-01', refApr1);
+      expect(result.gradeLabel).toBe('小学校 1年生');
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // 返り値の構造検証
+  // ----------------------------------------------------------------
+  describe('返り値の構造', () => {
+    it('age, gradeLabel, stage, isAdult の 4 プロパティを持つオブジェクトを返す', () => {
+      const result = calculateStudentInfo('2014-04-01', REF_DATE);
+      expect(result).toHaveProperty('age');
+      expect(result).toHaveProperty('gradeLabel');
+      expect(result).toHaveProperty('stage');
+      expect(result).toHaveProperty('isAdult');
+    });
+
+    it('age は数値型', () => {
+      const result = calculateStudentInfo('2010-06-01', REF_DATE);
+      expect(typeof result.age).toBe('number');
+    });
+
+    it('isAdult は真偽値型', () => {
+      const result = calculateStudentInfo('2010-06-01', REF_DATE);
+      expect(typeof result.isAdult).toBe('boolean');
+    });
+  });
+});


### PR DESCRIPTION
## 概要

- `calculateStudentInfo` 関数の境界値テスト・年齢計算精度・学年判定正確性を検証する単体テストを追加
- Issue #12 (N-006) の全受入条件（AC-070〜AC-073）を満たす 31 テストケースを実装
- 基準日固定により再現性を確保（NFR-001 準拠）

## 変更内容

- `frontend/src/utils/gradeCalculator.test.js` を新規作成（31 テストケース）
  - 学校段階境界値テスト（未就学/小学校/中学校/高校/卒業生）
  - 年齢計算精度（誕生日当日・前日・翌日、年またぎ）
  - 4月1日と4月2日生まれの学年差異
  - `isAdult` フラグの満20歳境界
  - 学校年度境界（1〜3月の前年度扱い）
  - 返り値構造検証

## 受入条件（AC）

- [x] AC-001: 要件・ポリシー・制約に整合している
- [x] AC-010: 必要なテストが追加または更新されている（31 テスト追加）
- [x] AC-020: CI（lint/type/test/policy_check）が成功している
- [x] AC-030: 変更に応じて正本 docs を更新した（テスト追加のみのため更新不要）
- [x] AC-040: 検証手順と結果を本 PR に記載した
- [x] AC-050: 禁止操作や秘密情報の混入がない

## 検証

### ローカル CI 実行結果

```bash
# ESLint
$ npx eslint src --max-warnings=0
✓ エラーなし

# Jest テスト（全 98 テスト）
$ CI=true npm test
Test Suites: 8 passed, 8 total
Tests:       98 passed, 98 total
- 既存テスト: 67 件
- 新規テスト: 31 件（gradeCalculator.test.js）

# pytest（バックエンド）
$ pytest tests/ -v
13 passed

# Policy Check
$ python ci/policy_check.py
[policy_check] OK
```

### 監査結果

| 監査担当 | Must | Should | Nice |
|---|---|---|---|
| auditor-spec | 0 | 3 | 3 |
| auditor-reliability | 0 | 5 | 3 |
| auditor-security | 0 | 2 | 1 |

**Must 指摘: 0 件（監査通過）**

Should 指摘の主要項目：
- `isAdult` 概念が requirements.md に未記載（S-1）
- タイムゾーン依存の再現性リスク（S-2）
- エラーケースのテスト不足（S-3）
- 未就学ステージ仕様の根拠未確認（S-4）

## 影響範囲 / リスク

- **影響範囲**: テストコードのみ追加、実装コードへの変更なし
- **残リスク**: 
  - タイムゾーン UTC-2 以西での `new Date('YYYY-MM-DD')` 解析による年度境界テスト失敗の可能性（低）
  - 不正入力に対するバリデーションテスト未実装（実用上のリスクは低、ダミーデータ固定のため）
- **ロールバック方針**: テストファイル削除のみで完全にロールバック可能

## 追加メモ

### 監査観点での注意点

- **仕様整合性**: `isAdult` フラグの法的年齢基準（20歳 vs 18歳）と権限移譲の目的が requirements.md に未記載
- **再現性**: 基準日 `new Date('2026-04-15')` で固定済みだが、UTC/JST 混在時の挙動は要注意
- **セキュリティ**: クライアントサイド計算の `isAdult` が将来的に認可制御に使われないよう、architecture.md への明記を推奨

### AC 対応表

| AC | 条件 | 状態 |
|---|---|---|
| AC-070 | 境界値テスト（小学校入学前後、学年境界、満20歳） | ✅ 10 テスト |
| AC-071 | 年齢計算の精度（誕生日当日と前日） | ✅ 5 テスト |
| AC-072 | 学年判定の正確性（4月1日と4月2日生まれ） | ✅ 4 テスト |
| AC-073 | `isAdult` フラグの正確性（満20歳境界） | ✅ 5 テスト |

---

Closes #12
